### PR TITLE
change strategy from rolling to recreate

### DIFF
--- a/openshift/mattermost-push-proxy.app.yaml
+++ b/openshift/mattermost-push-proxy.app.yaml
@@ -34,13 +34,9 @@ objects:
         limits:
             cpu: 200m
             memory: 1Gi
-    rollingParams:
-        intervalSeconds: 1
-        maxSurge: 25%
-        maxUnavailable: 25%
-        timeoutSeconds: 600
-        updatePeriodSeconds: 1
-    type: Rolling
+    type: Recreate
+    recreateParams:
+      timeoutSeconds: 600 
     template:
       metadata:
         creationTimestamp: null


### PR DESCRIPTION
because we can't use rolling update strategy with PVs that can't be shared