### PR TITLE
remove persistentVolumeClaim

### DIFF
--- a/openshift/mattermost-push-proxy.app.yaml
+++ b/openshift/mattermost-push-proxy.app.yaml
@@ -4,16 +4,6 @@ metadata:
   name: mattermost-push-proxy
   creationTimestamp: null
 objects:
-- kind: PersistentVolumeClaim
-  apiVersion: v1
-  metadata:
-    name: "mattermost-push-proxy-config"
-  spec:
-    accessModes:
-      - ReadWriteOnce
-    resources:
-      requests:
-        storage: "1Gi"
 - kind: DeploymentConfig
   apiVersion: v1
   metadata:
@@ -81,17 +71,9 @@ objects:
                 secretKeyRef:
                   name: mattermost-push-proxy-config
                   key: applepushrnpass
-          volumeMounts:
-            - name: config
-              mountPath: /opt/mattermost-push-proxy/config
-        volumes:
-        - name: config
-          persistentVolumeClaim:
-            claimName: mattermost-push-proxy-config
         resources: {}
         terminationMessagePath: /dev/termination-log
         readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /
               port: 8066


### PR DESCRIPTION
remove persistentVolumeClaim:
changed the usage of pvc for writable file system and made the directory permission to writable in the Dockerfile itself
(https://github.com/syamgk/mm-push-proxy/blob/master/3.10.0/Dockerfile#L16)
       \+  fix typo