### PR TITLE
Set value for image tag using IMAGE_TAG parameter

### DIFF
--- a/openshift/mattermost-push-proxy.app.yaml
+++ b/openshift/mattermost-push-proxy.app.yaml
@@ -44,7 +44,7 @@ objects:
           service: mattermost-push-proxy
       spec:
         containers:
-        - image: registry.centos.org/mattermost/mattermost-push-proxy:3.10.0
+        - image: registry.centos.org/mattermost/mattermost-push-proxy:${IMAGE_TAG}
           imagePullPolicy: Always
           name: mattermost-push-proxy
           ports:
@@ -157,4 +157,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
-  value: latest
+  value: 3.10.0


### PR DESCRIPTION
Use the IMAGE_TAG parameter to set the tag of image being pulled, instead of hardcoding it in the URL.

Related: #10 