### PR TITLE
Set value for IMAGE_TAG as string

### DIFF
--- a/openshift/mattermost-push-proxy.app.yaml
+++ b/openshift/mattermost-push-proxy.app.yaml
@@ -139,4 +139,4 @@ objects:
   status: {}
 parameters:
 - name: IMAGE_TAG
-  value: 3.10.0
+  value: "3.10.0"


### PR DESCRIPTION
Set the value of the IMAGE_TAG parameter as string instead of an int.
Openshift fails to process the file if the value is an int.