### PR TITLE
Use IMAGE_TAG_VERSION parameter to set Image Version

### DIFF
--- a/cico_build_deploy.sh
+++ b/cico_build_deploy.sh
@@ -16,7 +16,7 @@ TEMPLATE="openshift/mattermost-push-proxy.app.yaml"
 
 #Find tag used by deployment template
 echo -e "Scanning OpenShift Deployment Template for Image tag"
-TAG=$(cat $TEMPLATE | grep -o -e "registry.*" | awk '{split($0,array,"/")} END{print array[3]}' | awk '{split($0,array,":")} END{print array[2]}')
+TAG=$(cat $TEMPLATE | grep -A 1 "name: IMAGE_TAG_VERSION" | grep "value:" |  awk '{split($0,array,":")} END{print array[2]}')
 
 #Check if image is in the registry
 echo -e "Checking if image exists on the registry"

--- a/openshift/mattermost-push-proxy.app.yaml
+++ b/openshift/mattermost-push-proxy.app.yaml
@@ -34,7 +34,7 @@ objects:
           service: mattermost-push-proxy
       spec:
         containers:
-        - image: registry.centos.org/mattermost/mattermost-push-proxy:${IMAGE_TAG}
+        - image: registry.centos.org/mattermost/mattermost-push-proxy:${IMAGE_TAG_VERSION}
           imagePullPolicy: Always
           name: mattermost-push-proxy
           ports:
@@ -138,5 +138,6 @@ objects:
     wildcardPolicy: None
   status: {}
 parameters:
+- name: IMAGE_TAG_VERSION
+  value: "3.10.0"
 - name: IMAGE_TAG
-  value: 3.10.0


### PR DESCRIPTION
Add a new parameter IMAGE_TAG_VERSION to store the value of image tag.
Retained the old IMAGE_TAG variable as its required by saasherder. Fix
the value type of parameter to use string instead of int.